### PR TITLE
Updated lifecycle badge in README.MD

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![lifecycle](https://img.shields.io/badge/lifecycle-experimental-orange.svg)](https://www.tidyverse.org/lifecycle/#experimental)
+[![lifecycle](https://img.shields.io/badge/lifecycle-superseded-orange.svg)](https://github.com/NeotomaDB/Workshops/#superseded)
 [![NSF-1948926](https://img.shields.io/badge/NSF-1948926-blue.svg)](https://nsf.gov/awardsearch/showAward?AWD_ID=1948926)
 # AMQUA  Workflows and Sample Binder
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![lifecycle](https://img.shields.io/badge/lifecycle-superseded-orange.svg)](https://github.com/NeotomaDB/Workshops/#superseded)
+[![lifecycle](https://img.shields.io/badge/lifecycle-superseded-orange.svg)](https://github.com/NeotomaDB/Workshops)
 [![NSF-1948926](https://img.shields.io/badge/NSF-1948926-blue.svg)](https://nsf.gov/awardsearch/showAward?AWD_ID=1948926)
 # AMQUA  Workflows and Sample Binder
 


### PR DESCRIPTION
Updated lifecycle badge from experimental to superseded. Also replaced tidyverse url to a link the relevant "Workshops" repo.